### PR TITLE
Allow composer to see the master branch

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,26 @@
+{
+  "name": "ministryofjustice/intranet-theme-clarity",
+  "type": "wordpress-theme",
+  "license": "",
+  "description": "The Clarity WordPress theme of the MoJ Intranet",
+  "homepage": "https://github.com/ministryofjustice/mojintranet-theme",
+  "authors": [
+    {
+      "name": "Intranet team",
+      "email": "intranet-support@digital.service.go.uk"
+    }
+  ],
+  "keywords": [
+    "wordpress", "theme"
+  ],
+  "support": {
+    "issues": "https://github.com/ministryofjustice/intranet-theme-clarity/issues"
+  },
+  "require": {
+    "php": ">=5.7",
+    "composer/installers": "~1.2.0"
+  },
+  "extra" : {
+    "installer-name": "intranet-theme-clarity"
+  }
+}


### PR DESCRIPTION
For some reason, composer in the intranet docker container cannot see
the master branch.  I believe this is due to the missing composer.json
file, so I am putting it in to master to test this hypothesis.